### PR TITLE
Let git tell us where git-sh-setup is located

### DIFF
--- a/git-crawl
+++ b/git-crawl
@@ -1,6 +1,6 @@
 #!/bin/sh
 USAGE="<commit-ish>"
-. git-sh-setup
+. "$(git --exec-path)/git-sh-setup"
 test -n "$*" || usage
 
 next_commit=$(git rev-list --reverse HEAD..$1 | head -1)


### PR DESCRIPTION
According to the docs, recommended sourcing of git-sh-setup should be relative to git's exec-path (returned from `git --exec-path`)

This makes git-crawl executable as `git-crawl` as well as `git crawl`.
