### PR TITLE
checkout ref when reached

### DIFF
--- a/git-crawl
+++ b/git-crawl
@@ -4,5 +4,5 @@ USAGE="<commit-ish>"
 test -n "$*" || usage
 
 next_commit=$(git rev-list --reverse HEAD..$1 | head -1)
-test -n "$next_commit" || die "no commit found towards $1"
+: ${next_commit:=$1}
 git checkout $next_commit


### PR DESCRIPTION
when next_commit is empty (means target has been reached), set the 'checkout target' to be the ref, rather than sha
